### PR TITLE
125 refatoracao pr automatico

### DIFF
--- a/src/modules/services.js
+++ b/src/modules/services.js
@@ -1,9 +1,33 @@
 import {criarRelatorio} from './relatorio.js';
 export function criarPullRequest() {
   
+  var xhr = new XMLHttpRequest();
+  var owner = localStorage.getItem('owner');
+  var repo = localStorage.getItem('repo');
+
+  xhr.addEventListener("readystatechange", function() {
+    if(xhr.readyState === 4) {
+        var branches = JSON.parse(xhr.responseText);
+        var optionsBranches1 = `<select id='opt1'><option></option>`;
+
+        for(var i = 1; i <= branches.length; i++) {
+          optionsBranches1 += `<option id='opt1 ${i}'>${branches[i-1].name}</option>`;
+        }
+        optionsBranches1 += `</select>`;
+        var optionsBranches2 = optionsBranches1.replace('opt1', 'opt2');
+        criarModal(optionsBranches1, optionsBranches2);
+    }
+  });
+
+  xhr.open("GET", `https://api.github.com/repos/${owner}/${repo}/branches`);
+  xhr.send();
+}
+
+function criarModal(optionsBranches1, optionsBranches2){
+  
   //CRIANDO MODAL APÓS FECHAMENTO DA MILESTONE
       const modal = document.createElement('div');
-      modal.innerHTML = `<style> .modal { width: 100vw; height: 100vh;background: rgba(0,0,0,.5);position: fixed;top: 0px;left: 0px;z-index: 2000;display: none;justify-content: center;align-items: center;}.modal.mostrar {display: flex;}.modal-dialog {background: #24292e;width: 40%;min-width: 300px;padding: 40px;position: relative.texto {color: white;}</style><div class="modal" id="modal-mensagem"><div class="modal-dialog"><div class="modal-content">    <div class="modal-header"><button type="button" class="btn" id="fechar">×</button> <center><h3 class="texto">Insira as informações abaixo para a solicitação do Pull Request:</h3></center>        <br>    </div>    <div class="modal-body">            <form>        <fieldset><label class="texto"> Qual a branch para merge?   </label><input type="text" id = "currentBranch"><br> <label class="texto"> Qual a branch destino?  </label><input type="text" id = "recieveBranch"><br> <br> <label class="texto"> Quais foram as issues relacionadas? (ex.: #10 #11)  </label><input type="text" id = "issues"><br> <br><label class="texto"> Quais foram as alterações feitas?  </label> <br> <input type = "checkbox" id = "documentação" class="texto"><label class="texto"> Alteração em documentação </label><br> <input type = "checkbox" id = "funcionalidade" class="texto"><label class="texto"> Nova funcionalidade </label><br> <input type = "checkbox" id = "funcionalidadeModificada" class="texto"><label class="texto"> Alteração em funcionalidade </label><br> <input type = "checkbox" id = "correçãoBug" class="texto"><label class="texto"> Correção de bug </label><br> <input type = "checkbox" id = "outro" class="texto"><label class="texto"> Outro   </label><input type = "text" id = "outraOpcao">    </fieldset></form> </div><div class="modal-footer">    <br>        <button type="button" class="btn" data-dismiss="modal" id = "submit">Concluir</button>    </div></div></div></div>`
+      modal.innerHTML = `<style> .modal { width: 100vw; height: 100vh;background: rgba(0,0,0,.5);position: fixed;top: 0px;left: 0px;z-index: 2000;display: none;justify-content: center;align-items: center;}.modal.mostrar {display: flex;}.modal-dialog {background: #24292e;width: 40%;min-width: 300px;padding: 40px;position: relative.texto {color: white;}</style><div class="modal" id="modal-mensagem"><div class="modal-dialog"><div class="modal-content">    <div class="modal-header"><button type="button" class="btn" id="fechar">×</button> <center><h3 class="texto">Insira as informações abaixo para a solicitação do Pull Request:</h3></center>        <br>    </div>    <div class="modal-body">            <form>        <fieldset><label class="texto"> Qual a branch para merge?   </label> ${optionsBranches1} <br> <br> <label class="texto"> Qual a branch destino?  </label> ${optionsBranches2} <br> <br> <label class="texto"> Quais foram as issues relacionadas? (ex.: #10 #11)  </label><input type="text" id = "issues"><br> <br><label class="texto"> Quais foram as alterações feitas?  </label> <br> <input type = "checkbox" id = "documentação" class="texto"><label class="texto"> Alteração em documentação </label><br> <input type = "checkbox" id = "funcionalidade" class="texto"><label class="texto"> Nova funcionalidade </label><br> <input type = "checkbox" id = "funcionalidadeModificada" class="texto"><label class="texto"> Alteração em funcionalidade </label><br> <input type = "checkbox" id = "correçãoBug" class="texto"><label class="texto"> Correção de bug </label><br> <input type = "checkbox" id = "outro" class="texto"><label class="texto"> Outro   </label><input type = "text" id = "outraOpcao">    </fieldset></form> </div><div class="modal-footer">    <br>        <button type="button" class="btn" data-dismiss="modal" id = "submit">Concluir</button>    </div></div></div></div>`
       const body = document.body || document.getElementsByTagName("body")[0] || document.documentElement;
       body.insertBefore(modal, body.lastChild);
   
@@ -24,8 +48,17 @@ export function criarPullRequest() {
   
       iniciaModal("modal-mensagem")
   
+
       //EVENTO CLICK NO BOTÃO SUBMIT DO MODAL
   document.addEventListener("click", function (e) {
+
+      if(e.target.id == "opt1") {
+        window.currentBranch = e.target.value;
+      }
+      if(e.target.id == "opt2"){
+        window.recieveBranch = e.target.value;
+      }
+      
       if(e.target.id == "submit") {
         
         var chkDoc = document.getElementById("documentação");
@@ -34,8 +67,6 @@ export function criarPullRequest() {
         var chkBug = document.getElementById("correçãoBug");
         var chkOutro = document.getElementById("outro");
         var issues = document.getElementById("issues");
-        var recieveBranch = document.getElementById("recieveBranch");
-        var currentBranch = document.getElementById("currentBranch");
         var alteracoes = '';
     
     //CONSTRUINDO STRING COM ALTERAÇÕES FEITAS NA BRANCH
@@ -71,18 +102,16 @@ export function criarPullRequest() {
     var data = JSON.stringify({
           "title": `# Fechamento da milestone: ${$NumberMilestone} - ${milestoneName}`,
           "body": 
-                  `# Fechamento da milestone: ${$NumberMilestone} - ${milestoneName} \n## Descrição \nSolicita-se um Pull Request para que seja feito o merge das alterações realizadas da branch ${currentBranch.value} para a branch ${recieveBranch.value}. \n  ## Issue(s) Relacionada(s) \n${issues.value} \n## Tipo de Alteração \nForam feitas as seguintes alterações na branch ${currentBranch.value}: ${alteracoes}`,
+                  `# Fechamento da milestone: ${$NumberMilestone} - ${milestoneName} \n## Descrição \nSolicita-se um Pull Request para que seja feito o merge das alterações realizadas da branch ${currentBranch} para a branch ${recieveBranch}. \n  ## Issue(s) Relacionada(s) \n${issues.value} \n## Tipo de Alteração \nForam feitas as seguintes alterações na branch ${currentBranch}: ${alteracoes}`,
   
-          "head": currentBranch.value,
-          "base": recieveBranch.value
+          "head": currentBranch,
+          "base": recieveBranch
         });
         
   
     var xhr = new XMLHttpRequest();
        xhr.addEventListener("readystatechange", function () {
-          if (xhr.readyState === 4) {
-            
-          }
+          if (xhr.readyState === 4) {}
         });
        
         xhr.open("POST", "https://api.github.com/repos/" + $owner + "/" + $repo + "/pulls");
@@ -99,8 +128,3 @@ export function criarPullRequest() {
       }}) 
 
   }
-
-
-
-
-

--- a/src/modules/services.js
+++ b/src/modules/services.js
@@ -7,7 +7,8 @@ export function criarPullRequest() {
 
   xhr.addEventListener("readystatechange", function() {
     if(xhr.readyState === 4) {
-        var branches = JSON.parse(xhr.responseText);
+  
+      var branches = JSON.parse(xhr.responseText);
         var optionsBranches1 = `<select id='opt1'><option></option>`;
 
         for(var i = 1; i <= branches.length; i++) {
@@ -26,69 +27,77 @@ export function criarPullRequest() {
 function criarModal(optionsBranches1, optionsBranches2){
   
   //CRIANDO MODAL APÓS FECHAMENTO DA MILESTONE
-      const modal = document.createElement('div');
-      modal.innerHTML = `<style> .modal { width: 100vw; height: 100vh;background: rgba(0,0,0,.5);position: fixed;top: 0px;left: 0px;z-index: 2000;display: none;justify-content: center;align-items: center;}.modal.mostrar {display: flex;}.modal-dialog {background: #24292e;width: 40%;min-width: 300px;padding: 40px;position: relative.texto {color: white;}</style><div class="modal" id="modal-mensagem"><div class="modal-dialog"><div class="modal-content">    <div class="modal-header"><button type="button" class="btn" id="fechar">×</button> <center><h3 class="texto">Insira as informações abaixo para a solicitação do Pull Request:</h3></center>        <br>    </div>    <div class="modal-body">            <form>        <fieldset><label class="texto"> Qual a branch para merge?   </label> ${optionsBranches1} <br> <br> <label class="texto"> Qual a branch destino?  </label> ${optionsBranches2} <br> <br> <label class="texto"> Quais foram as issues relacionadas? (ex.: #10 #11)  </label><input type="text" id = "issues"><br> <br><label class="texto"> Quais foram as alterações feitas?  </label> <br> <input type = "checkbox" id = "documentação" class="texto"><label class="texto"> Alteração em documentação </label><br> <input type = "checkbox" id = "funcionalidade" class="texto"><label class="texto"> Nova funcionalidade </label><br> <input type = "checkbox" id = "funcionalidadeModificada" class="texto"><label class="texto"> Alteração em funcionalidade </label><br> <input type = "checkbox" id = "correçãoBug" class="texto"><label class="texto"> Correção de bug </label><br> <input type = "checkbox" id = "outro" class="texto"><label class="texto"> Outro   </label><input type = "text" id = "outraOpcao">    </fieldset></form> </div><div class="modal-footer">    <br>        <button type="button" class="btn" data-dismiss="modal" id = "submit">Concluir</button>    </div></div></div></div>`
-      const body = document.body || document.getElementsByTagName("body")[0] || document.documentElement;
-      body.insertBefore(modal, body.lastChild);
-  
-      //FUNÇÃO QUE ABRE O MODAL
-      function iniciaModal(modalID) {
-          const modal = document.getElementById(modalID);
-          if (modal) {
-              modal.classList.add('mostrar');
-              
-              //FECHAR MODAL APERTANDO O "X"
-              modal.addEventListener('click', function (e) {
-                  if (e.target.id == 'fechar'){
-                      modal.classList.remove('mostrar');
-                  }
-              })
-          }
-      }
-  
-      iniciaModal("modal-mensagem")
-  
+    const modal = document.createElement('div');
+    modal.innerHTML = `<style> .modal { width: 100vw; height: 100vh;background: rgba(0,0,0,.5);position: fixed;top: 0px;left: 0px;z-index: 2000;display: none;justify-content: center;align-items: center;}.modal.mostrar {display: flex;}.modal-dialog {background: #24292e;width: 40%;min-width: 300px;padding: 40px;position: relative.texto {color: white;}</style><div class="modal" id="modal-mensagem"><div class="modal-dialog"><div class="modal-content">    <div class="modal-header"><button type="button" class="btn" id="fechar">×</button> <center><h3 class="texto">Insira as informações abaixo para a solicitação do Pull Request:</h3></center>        <br>    </div>    <div class="modal-body">            <form>        <fieldset><label class="texto"> Qual a branch para merge?   </label> ${optionsBranches1} <br> <br> <label class="texto"> Qual a branch destino?  </label> ${optionsBranches2} <br> <br> <label class="texto"> Quais foram as issues relacionadas? (ex.: #10 #11)  </label><input type="text" id = "issues"><br> <br><label class="texto"> Quais foram as alterações feitas?  </label> <br> <input type = "checkbox" id = "documentação" class="texto"><label class="texto"> Alteração em documentação </label><br> <input type = "checkbox" id = "funcionalidade" class="texto"><label class="texto"> Nova funcionalidade </label><br> <input type = "checkbox" id = "funcionalidadeModificada" class="texto"><label class="texto"> Alteração em funcionalidade </label><br> <input type = "checkbox" id = "correçãoBug" class="texto"><label class="texto"> Correção de bug </label><br> <input type = "checkbox" id = "outro" class="texto"><label class="texto"> Outro   </label><input type = "text" id = "outraOpcao">    </fieldset></form> </div><div class="modal-footer">    <br>        <button type="button" class="btn" data-dismiss="modal" id = "submit">Concluir</button>    </div></div></div></div>`
+    const body = document.body || document.getElementsByTagName("body")[0] || document.documentElement;
+    body.insertBefore(modal, body.lastChild);
 
-      //EVENTO CLICK NO BOTÃO SUBMIT DO MODAL
+    //FUNÇÃO QUE ABRE O MODAL
+    function iniciaModal(modalID) {
+        const modal = document.getElementById(modalID);
+        if (modal) {
+            modal.classList.add('mostrar');
+            
+            //FECHAR MODAL APERTANDO O "X"
+            modal.addEventListener('click', function (e) {
+                if (e.target.id == 'fechar'){
+                    modal.classList.remove('mostrar');
+                }
+            })
+        }
+    }
+
+    iniciaModal("modal-mensagem")
+
+  //EVENTO CLICK NA LISTA DE BRANCHES PARA MERGE (branch mergeada)
   document.addEventListener("click", function (e) {
 
-      if(e.target.id == "opt1") {
-        window.currentBranch = e.target.value;
-      }
-      if(e.target.id == "opt2"){
-        window.recieveBranch = e.target.value;
-      }
-      
-      if(e.target.id == "submit") {
+    if(e.target.id == "opt1") {
+      window.currentBranch = e.target.value;
+    }
+  })
+
+  //EVENTO CLICK NA LISTA DE BRANCHES PARA MERGE (branch destino)
+  document.addEventListener("click", function (e) {
+
+    if(e.target.id == "opt2") {
+      window.recieveBranch = e.target.value;
+    }
+  })
+
+  //EVENTO CLICK NO BOTÃO SUBMIT DO MODAL
+  document.addEventListener("click", function (e) {
+
+    if(e.target.id == "submit") {
         
-        var chkDoc = document.getElementById("documentação");
-        var chkFuncionalidade = document.getElementById("funcionalidade");
-        var chkFuncionalidadeModificada = document.getElementById("funcionalidadeModificada");
-        var chkBug = document.getElementById("correçãoBug");
-        var chkOutro = document.getElementById("outro");
-        var issues = document.getElementById("issues");
-        var alteracoes = '';
-    
-    //CONSTRUINDO STRING COM ALTERAÇÕES FEITAS NA BRANCH
-        if (chkDoc.checked) {
-          alteracoes = `${alteracoes} \n* Alteração em documentação`
-        }
-    
-        if (chkFuncionalidade.checked) {
-          alteracoes = `${alteracoes} \n* Nova funcionalidade`
-        }
-    
-        if (chkFuncionalidadeModificada.checked) {
-          alteracoes = `${alteracoes} \n* Alteração em funcionalidade`
-        }
-    
-        if (chkBug.checked) {
-          alteracoes = `${alteracoes} \n* Correção de bug`
-        }
-    
-        if (chkOutro.checked) {
-          alteracoes = `${alteracoes} \n* ${document.getElementById("outraOpcao").value}`
-        }
+      var chkDoc = document.getElementById("documentação");
+      var chkFuncionalidade = document.getElementById("funcionalidade");
+      var chkFuncionalidadeModificada = document.getElementById("funcionalidadeModificada");
+      var chkBug = document.getElementById("correçãoBug");
+      var chkOutro = document.getElementById("outro");
+      var issues = document.getElementById("issues");
+      var alteracoes = '';
+  
+  //CONSTRUINDO STRING COM ALTERAÇÕES FEITAS NA BRANCH
+      if (chkDoc.checked) {
+        alteracoes = `${alteracoes} \n* Alteração em documentação`
+      }
+  
+      if (chkFuncionalidade.checked) {
+        alteracoes = `${alteracoes} \n* Nova funcionalidade`
+      }
+  
+      if (chkFuncionalidadeModificada.checked) {
+        alteracoes = `${alteracoes} \n* Alteração em funcionalidade`
+      }
+  
+      if (chkBug.checked) {
+        alteracoes = `${alteracoes} \n* Correção de bug`
+      }
+  
+      if (chkOutro.checked) {
+        alteracoes = `${alteracoes} \n* ${document.getElementById("outraOpcao").value}`
+      }
     
     const milestoneName = localStorage.getItem('milestoneName');
   
@@ -108,23 +117,21 @@ function criarModal(optionsBranches1, optionsBranches2){
           "base": recieveBranch
         });
         
-  
     var xhr = new XMLHttpRequest();
-       xhr.addEventListener("readystatechange", function () {
-          if (xhr.readyState === 4) {}
-        });
+    xhr.addEventListener("readystatechange", function () {
+      if (xhr.readyState === 4) {}
+    });
        
-        xhr.open("POST", "https://api.github.com/repos/" + $owner + "/" + $repo + "/pulls");
-        xhr.setRequestHeader("accept", "application/vnd.github.v3+json");
-        xhr.setRequestHeader("content-type", "application/json");
-        xhr.setRequestHeader("authorization", "Bearer " + token);
-        
+    xhr.open("POST", "https://api.github.com/repos/" + $owner + "/" + $repo + "/pulls");
+    xhr.setRequestHeader("accept", "application/vnd.github.v3+json");
+    xhr.setRequestHeader("content-type", "application/json");
+    xhr.setRequestHeader("authorization", "Bearer " + token);
     
-        xhr.send(data);
-  
-      //FECHANDO MODAL APÓS CONCLUIR INSTRUÇÕES
-        document.getElementById("modal-mensagem").classList.remove('mostrar');
-        criarRelatorio($owner,  $repo, milestoneName);
-      }}) 
 
-  }
+    xhr.send(data);
+
+  //FECHANDO MODAL APÓS CONCLUIR INSTRUÇÕES
+    document.getElementById("modal-mensagem").classList.remove('mostrar');
+    criarRelatorio($owner,  $repo, milestoneName);
+  }}) 
+}

--- a/src/testes/service.test.js
+++ b/src/testes/service.test.js
@@ -1,6 +1,13 @@
 import {criarPullRequest} from '../modules/services';
 import {criarRelatorio} from '../modules/relatorio';
 
+
+var objetoJson = [
+    {
+        name: 'nome'
+    }
+];
+
 // MOCK DA CLASSE XMLHttpRequest
 const mockXHR = {
     addEventListener: jest.fn(),
@@ -26,21 +33,29 @@ const mockXHR = {
         
       } catch (e) {}    }
     ),
+    responseText: objetoJson
 };
 window.XMLHttpRequest = jest.fn(() => mockXHR);
 
+// MOCK DE UM OBJETO JSON
+JSON.parse = jest.fn().mockReturnValue(objetoJson);
+JSON.stringify = jest.fn().mockReturnValue(null);
 
-// SIMULANDO CLICK NO BOTÃO "submit" DO MODAL
+
+// SIMULANDO CLICK'S NO MODAL
 global.evento = {
     target: {
-        id: "submit"
-    }}
+        id: "opt1",
+        value: "value"
+}};
 
 // MOCK DO OUVINTE document.addEventListener
 window.document.addEventListener = jest.fn(() => {
     try {
         var quantidadeDeChamadas = document.addEventListener.mock.calls.length;
         if(quantidadeDeChamadas > 0) {
+            if(quantidadeDeChamadas == 2) evento.target.id = "opt2";
+            if(quantidadeDeChamadas == 3) evento.target.id = "submit"; 
             document.addEventListener.mock.calls[quantidadeDeChamadas-1][1](evento);
             return;
         }
@@ -79,7 +94,8 @@ test('Testando criarPullRequest()', () => {
 
 
 test('Fechando modal e cancelando Pull Request', () => {
-    evento.target.id = "submit";
+    evento.target.id = "opt1";
+    document.addEventListener.mockClear();
     mockElementById.checked = false;
     criarPullRequest();
  
@@ -104,7 +120,7 @@ test('Fechando modal e cancelando Pull Request', () => {
     mockXHR.open.mockClear();
     mockXHR.send.mockClear();
     mockXHR.setRequestHeader.mockClear();
-         
+    
     criarPullRequest();
 
     
@@ -112,7 +128,7 @@ test('Fechando modal e cancelando Pull Request', () => {
     expect(mockElementById.classList.remove).toHaveBeenCalledTimes(1);
 
     // TESTANDO SE O PULL REQUEST NÃO FOI CRIADO
-    expect(mockXHR.open).toHaveBeenCalledTimes(0);
-    expect(mockXHR.send).toHaveBeenCalledTimes(0);
+    expect(mockXHR.open).toHaveBeenCalledTimes(1);
+    expect(mockXHR.send).toHaveBeenCalledTimes(1);
     expect(mockXHR.setRequestHeader).toHaveBeenCalledTimes(0);
 });


### PR DESCRIPTION
# Refatoração no PR automático

## Descrição

O usuário não precisará escrever os nomes das branches para abrir o Pull Request. A nova alteração faz com que seja aberta uma lista de opções com as branches ativas para que o usuário consiga selecioná-las. Além disso, o teste desse método foi modificado, incluindo as novas alterações.

## Issue Relacionada

#125 

## Como isso foi testado?

- [x] Testes unitários
- [x] Teste exploratório
- [ ] Não aplicável

## Como testar?
Fechando uma milestone, desta forma o modal com as opções será aberto, e executando o comando: **npm test** para visualizar os testes.

## Imagens (se aplicável)

![image](https://user-images.githubusercontent.com/78423506/118184877-454cbc80-b412-11eb-9c03-eed5d4eca648.png)

## Essa modificação exige atualização da documentação?

Não.

## Tipo de alteração

- [ ] Nova feature
- [ ] Correção de bugs
- [x] Alteração de uma funcionalidade já existente
- [ ] Documentação
